### PR TITLE
Glinet mango power cycle test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,3 +92,19 @@ $(curdir)/gl-mt300n-v2:
 		--lg-env $(TESTSDIR)/targets/gl-mt300n-v2.yaml \
 		--lg-log \
 		--log-cli-level=DEBUG
+
+$(curdir)/belkin_rt3200_1:
+	@echo "Running tests on physical Belkin RT3200 (1) device..."
+	@echo "Make sure the device is connected via serial and Arduino relay (channel 2)"
+	$(pytest) \
+		--lg-env $(TESTSDIR)/targets/belkin_rt3200_1.yaml \
+		--lg-log \
+		--log-cli-level=DEBUG
+
+$(curdir)/belkin_rt3200_2:
+	@echo "Running tests on physical Belkin RT3200 (2) device..."
+	@echo "Make sure the device is connected via serial and Arduino relay (channel 3)"
+	$(pytest) \
+		--lg-env $(TESTSDIR)/targets/belkin_rt3200_2.yaml \
+		--lg-log \
+		--log-cli-level=DEBUG

--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,11 @@ $(curdir)/malta-be:
 		$(pytest) \
 		--lg-env $(TESTSDIR)/targets/qemu-malta-be.yaml \
 		--firmware $(FIRMWARE)
+
+$(curdir)/gl-mt300n-v2:
+	@echo "Running tests on physical GL-MT300N-V2 device..."
+	@echo "Make sure the device is connected via serial and Arduino relay"
+	$(pytest) \
+		--lg-env $(TESTSDIR)/targets/gl-mt300n-v2.yaml \
+		--lg-log \
+		--log-cli-level=DEBUG

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ test: $(OPENWRT_CI_TESTS)
 TESTSDIR ?= $(shell readlink -f $(TOPDIR)/tests)
 
 define pytest
+	KEEP_DUT_ON=$(KEEP_DUT_ON) \
+	RESET_ALL_DUTS=$(RESET_ALL_DUTS) \
+	SUITE_OPTIMIZATION=$(SUITE_OPTIMIZATION) \
 	uv --project $(TESTSDIR) run \
 		pytest $(TESTSDIR)/tests/ \
 		--lg-log \
@@ -106,5 +109,16 @@ $(curdir)/belkin_rt3200_2:
 	@echo "Make sure the device is connected via serial and Arduino relay (channel 3)"
 	$(pytest) \
 		--lg-env $(TESTSDIR)/targets/belkin_rt3200_2.yaml \
+		--lg-log \
+		--log-cli-level=DEBUG
+
+$(curdir)/mesh_belkin_pair:
+	@echo "Running mesh tests on Belkin RT3200 pair..."
+	@echo "Make sure both devices are connected via serial and Arduino relay"
+	KEEP_DUT_ON=$(KEEP_DUT_ON) \
+	RESET_ALL_DUTS=$(RESET_ALL_DUTS) \
+	SUITE_OPTIMIZATION=$(SUITE_OPTIMIZATION) \
+	$(pytest) \
+		--lg-env $(TESTSDIR)/targets/mesh_belkin_pair.yaml \
 		--lg-log \
 		--log-cli-level=DEBUG

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,23 @@ $(curdir)/x86-64:
 		--lg-env $(TESTSDIR)/targets/qemu-x86-64.yaml \
 		--firmware $(FIRMWARE:.gz=)
 
+$(curdir)/x86-64-libremesh: QEMU_BIN ?= qemu-system-x86_64
+$(curdir)/x86-64-libremesh: FIRMWARE ?= $(TOPDIR)/bin/targets/x86/64/openwrt-x86-64-generic-squashfs-combined.img.gz
+$(curdir)/x86-64-libremesh:
+
+	[ -f $(FIRMWARE) ]
+
+	gzip \
+		--force \
+		--keep \
+		--decompress \
+		$(FIRMWARE) || true
+
+	LG_QEMU_BIN=$(QEMU_BIN) \
+		$(pytest) \
+		--lg-env $(TESTSDIR)/targets/qemu-libremesh-x86-64.yaml \
+		--firmware $(FIRMWARE:.gz=)
+
 $(curdir)/armsr-armv8: QEMU_BIN ?= qemu-system-aarch64
 $(curdir)/armsr-armv8: FIRMWARE ?= $(TOPDIR)/bin/targets/armsr/armv8/openwrt-armsr-armv8-generic-initramfs-kernel.bin
 $(curdir)/armsr-armv8:

--- a/drivers/serial_isolator_driver.py
+++ b/drivers/serial_isolator_driver.py
@@ -1,0 +1,46 @@
+import subprocess
+import attr
+from labgrid import target_factory
+from labgrid.driver import Driver
+from labgrid.resource import Resource
+from labgrid.step import step
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class SerialIsolatorResource(Resource):
+    """Recurso para controlar aislamiento de línea serial mediante relé."""
+    device = attr.ib(validator=attr.validators.instance_of(str))
+    channel = attr.ib(validator=attr.validators.instance_of(int))
+    baudrate = attr.ib(default=115200, validator=attr.validators.instance_of(int))
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class SerialIsolatorDriver(Driver):
+    """Driver para aislar/reconectar línea serial en routers que lo requieren."""
+
+    bindings = {
+        "resource": SerialIsolatorResource,
+    }
+
+    @step()
+    def disconnect(self):
+        """Desconecta la línea serial"""
+        cmd = [
+            "python3", "/home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py",
+            "--port", self.resource.device,
+            "--baudrate", str(self.resource.baudrate),
+            "on", str(self.resource.channel)
+        ]
+        subprocess.run(cmd, check=True)
+
+    @step()
+    def connect(self):
+        """Reconecta la línea serial"""
+        cmd = [
+            "python3", "/home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py",
+            "--port", self.resource.device,
+            "--baudrate", str(self.resource.baudrate),
+            "off", str(self.resource.channel)
+        ]
+        subprocess.run(cmd, check=True)

--- a/strategies/physicalstrategy.py
+++ b/strategies/physicalstrategy.py
@@ -6,12 +6,10 @@ from labgrid import target_factory
 from labgrid.step import step
 from labgrid.strategy import Strategy, StrategyError
 
-
 class Status(enum.Enum):
     unknown = 0
     off = 1
     shell = 2
-
 
 @target_factory.reg_driver
 @attr.s(eq=False)
@@ -34,10 +32,10 @@ class PhysicalDeviceStrategy(Strategy):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         # Serial isolator (si existe)
-        # try:
-        #     self.serial_isolator = self.target.get_driver("SerialIsolatorDriver")
-        # except Exception:
-        #     self.serial_isolator = None
+        try:
+            self.serial_isolator = self.target.get_driver("SerialIsolatorDriver")
+        except Exception:
+            self.serial_isolator = None
         try: # SerialDriver (para "activar" consola con Enter)
             self.serial = self.target.get_driver("SerialDriver")
         except Exception:
@@ -118,13 +116,13 @@ class PhysicalDeviceStrategy(Strategy):
 
             if self.requires_serial_disconnect: #and self.serial_isolator:
                 # Secuencia especial GL-iNet
-                #self.target.activate(self.serial_isolator)
+                self.target.activate(self.serial_isolator)
                 self.power.off()
-                #self.serial_isolator.disconnect()
+                self.serial_isolator.disconnect()
                 sleep(3)
                 self.power.on()
                 sleep(self.boot_wait)
-                #self.serial_isolator.connect()
+                self.serial_isolator.connect()
                 sleep(8)
             else:
                 # Arranque estándar

--- a/strategies/physicalstrategy.py
+++ b/strategies/physicalstrategy.py
@@ -1,0 +1,202 @@
+import enum
+from time import sleep, time
+import attr
+import allure
+from labgrid import target_factory
+from labgrid.step import step
+from labgrid.strategy import Strategy, StrategyError
+
+
+class Status(enum.Enum):
+    unknown = 0
+    off = 1
+    shell = 2
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class PhysicalDeviceStrategy(Strategy):
+    bindings = {
+        "power": "ExternalPowerDriver", # Esto le dice a Labgrid: "Cuando alguien acceda a self.power, dame una instancia del ExternalPowerDriver"
+        "shell": "ShellDriver",
+        # "ssh": "SSHDriver",  # opcional: comentar si no se usa
+    }
+
+    # Configuración de quirks
+    requires_serial_disconnect = attr.ib(default=False)
+    boot_wait = attr.ib(default=20)
+    connection_timeout = attr.ib(default=60)
+    smart_state_detection = attr.ib(default=True)
+    fast_check_timeout = attr.ib(default=3)
+
+    status = attr.ib(default=Status.unknown)
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        # Serial isolator (si existe)
+        # try:
+        #     self.serial_isolator = self.target.get_driver("SerialIsolatorDriver")
+        # except Exception:
+        #     self.serial_isolator = None
+        try: # SerialDriver (para "activar" consola con Enter)
+            self.serial = self.target.get_driver("SerialDriver")
+        except Exception:
+            self.serial = None
+
+    @step()
+    def _check_shell_active(self):
+        """Verifica si el shell ya está activo sin hacer power cycle."""
+        if not self.smart_state_detection:
+            return False
+
+        try:
+            # VERIFICACIÓN RÁPIDA SIN ACTIVAR SHELL
+            # Solo verificamos si el SerialDriver puede leer algo inmediatamente
+            if not hasattr(self.target, 'get_driver'):
+                return False
+            try:
+                serial_driver = self.target.get_driver("SerialDriver")
+            except:
+                return False
+
+            # Verificación súper rápida: enviar comando y leer con timeout mínimo
+            try:
+                serial_driver.sendline("echo test_active")
+                # Timeout de solo 2 segundos
+                result = serial_driver.expect(["test_active", "login:", "#"], timeout=2)
+
+                # Si recibimos cualquier respuesta válida, el router está activo
+                if result[0] in [0, 2]:  # test_active o prompt
+                    return True
+                else:
+                    return False
+
+            except Exception:
+                # Si hay timeout o error, router está apagado/no responde
+                return False
+
+        except Exception:
+            return False
+
+    @step()
+    def _ensure_shell_ready_fast(self):
+        """Verificación rápida de que el shell sigue funcionando correctamente."""
+        try:
+            # Comando de verificación más completo
+            result = self.shell.run("uname && echo ready", timeout=5)
+            if result[2] == 0 and result[0] and len(result[0]) >= 2:
+                if "Linux" in result[0][0] and "ready" in result[0][1]:
+                    return True
+            return False
+        except Exception:
+            return False
+
+    @step(args=["state"])
+    def transition(self, state, *, step):
+        if not isinstance(state, Status):
+            state = Status[state]
+
+        if state == Status.unknown:
+            raise StrategyError(f"can not transition to {state}")
+        elif self.status == state:
+            step.skip("nothing to do")
+            return
+
+        if state == Status.off:
+            self.target.activate(self.power)
+            self.power.off()
+
+        elif state == Status.shell:
+            # Verificación simple: ¿ya está activo?
+            if self._check_shell_active():
+                step.skip("shell already active and ready")
+                self.status = Status.shell
+                return
+
+            # Si llegamos aquí, hacer power cycle completo
+            self.target.activate(self.power)
+
+            if self.requires_serial_disconnect: #and self.serial_isolator:
+                # Secuencia especial GL-iNet
+                #self.target.activate(self.serial_isolator)
+                self.power.off()
+                #self.serial_isolator.disconnect()
+                sleep(3)
+                self.power.on()
+                sleep(self.boot_wait)
+                #self.serial_isolator.connect()
+                sleep(8)
+            else:
+                # Arranque estándar
+                self.power.on()
+                sleep(self.boot_wait)
+
+            # Activar shell normalmente
+            self._wait_for_shell_ready()
+
+        self.status = state
+
+    @step()
+    def _poke_console(self):
+        """Envía uno/dos 'Enter' por serial para activar la consola si está dormida."""
+        if not self.serial:
+            return
+        try:
+            # En algunos getty hace falta apretar Enter más de una vez
+            for _ in range(2):
+                self.serial.sendline("")  # equivale a '\n'
+                sleep(0.1)
+        except Exception as e:
+            allure.attach(str(e), "poke-console-error", allure.attachment_type.TEXT)
+
+    @step()
+    def _wait_for_shell_ready(self):
+        """Espera activamente a que el shell esté listo con timeout robusto."""
+
+        # 1) ACTIVAR SERIAL Y DESPERTAR CONSOLA ANTES DE SHELL
+        if self.serial:
+            self.target.activate(self.serial)
+            # Enviar varios Enter para salir de "Please press Enter to activate this console."
+            for _ in range(6):
+                try:
+                    self.serial.sendline("")
+                except Exception:
+                    pass
+                sleep(0.2)
+
+        # 2) Ahora sí, activar el shell (ya no debería bloquearse)
+        self.target.activate(self.shell)
+
+        start_time = time()
+        last_error = None
+
+        # Primer poke adicional por si acaso
+        self._poke_console()
+
+        while time() - start_time < self.connection_timeout:
+            try:
+                result = self.shell.run("echo 'ready'", timeout=5)
+                if result[2] == 0 and result[0] and "ready" in result[0][0]:
+                    return
+            except Exception as e:
+                last_error = str(e)
+
+            sleep(2)
+            self._poke_console()
+
+        msg = f"Shell no estuvo listo en {self.connection_timeout} segundos"
+        if last_error:
+            allure.attach(last_error, "shell-readiness-last-error", allure.attachment_type.TEXT)
+            msg += f". Último error: {last_error}"
+        raise StrategyError(msg)
+
+    @step()
+    def force_power_cycle(self):
+        """Fuerza un power cycle completo, ignorando optimizaciones."""
+        original_smart = self.smart_state_detection
+        try:
+            self.smart_state_detection = False
+            self.status = Status.unknown  # Forzar transición
+            self.transition("shell")
+        finally:
+            self.smart_state_detection = original_smart

--- a/strategies/qemunetworkstrategy.py
+++ b/strategies/qemunetworkstrategy.py
@@ -51,12 +51,15 @@ class QEMUNetworkStrategy(Strategy):
     @step()
     def update_network_service(self):
         self.shell.run("ubus wait_for network.interface.lan")
-        while not ubus_call(self.shell, "network.interface.lan", "status").get(
-            "ipv4-address"
-        ):
+        while True :
+            lan_status = ubus_call(self.shell, "network.interface.lan", "status").get(
+                "ipv4-address"
+            )
+            if lan_status:
+                break
             sleep(1)
 
-        lan_address = "192.168.1.1"
+        lan_address = lan_status[0]["address"]
         networkservice = self.ssh.networkservice
 
         if networkservice.address != lan_address:

--- a/targets/belkin_rt3200_1.yaml
+++ b/targets/belkin_rt3200_1.yaml
@@ -14,8 +14,8 @@ targets:
 
     drivers:
       ExternalPowerDriver:
-        cmd_on: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py off 2"
-        cmd_off: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py on 2"
+        cmd_on: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py on 2"
+        cmd_off: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py off 2"
 
       SerialDriver:
         txdelay: 0.05

--- a/targets/belkin_rt3200_1.yaml
+++ b/targets/belkin_rt3200_1.yaml
@@ -1,0 +1,43 @@
+targets:
+  main:
+    features:
+      - power
+
+    resources:
+      RawSerialPort:
+        port: "/dev/belkin-rt3200-1"
+        speed: 115200
+
+      NetworkService:
+        address: "192.168.20.183"
+        username: "root"
+
+    drivers:
+      ExternalPowerDriver:
+        cmd_on: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py off 2"
+        cmd_off: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py on 2"
+
+      SerialDriver:
+        txdelay: 0.05
+
+      ShellDriver:
+        prompt: '[\r\n]+.*?root@.*?#\s*'
+        login_prompt: 'Please press Enter to activate this console\.'
+        username: 'root'
+        await_login_timeout: 15
+        login_timeout: 120
+        post_login_settle_time: 5
+
+      SSHDriver:
+        connection_timeout: 30.0
+        explicit_scp_mode: True
+
+      PhysicalDeviceStrategy:
+        requires_serial_disconnect: false
+        boot_wait: 30
+        connection_timeout: 30
+        smart_state_detection: true
+        fast_check_timeout: 3
+
+imports:
+  - ../strategies/physicalstrategy.py

--- a/targets/belkin_rt3200_2.yaml
+++ b/targets/belkin_rt3200_2.yaml
@@ -1,0 +1,43 @@
+targets:
+  main:
+    features:
+      - power
+
+    resources:
+      RawSerialPort:
+        port: "/dev/belkin-rt3200-2"
+        speed: 115200
+
+      NetworkService:
+        address: "192.168.20.183"
+        username: "root"
+
+    drivers:
+      ExternalPowerDriver:
+        cmd_on: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py off 3"
+        cmd_off: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py on 3"
+
+      SerialDriver:
+        txdelay: 0.05
+
+      ShellDriver:
+        prompt: '[\r\n]+.*?root@.*?#\s*'
+        login_prompt: 'Please press Enter to activate this console\.'
+        username: 'root'
+        await_login_timeout: 15
+        login_timeout: 120
+        post_login_settle_time: 5
+
+      SSHDriver:
+        connection_timeout: 30.0
+        explicit_scp_mode: True
+
+      PhysicalDeviceStrategy:
+        requires_serial_disconnect: false
+        boot_wait: 30
+        connection_timeout: 30
+        smart_state_detection: true
+        fast_check_timeout: 3
+
+imports:
+  - ../strategies/physicalstrategy.py

--- a/targets/belkin_rt3200_2.yaml
+++ b/targets/belkin_rt3200_2.yaml
@@ -14,8 +14,8 @@ targets:
 
     drivers:
       ExternalPowerDriver:
-        cmd_on: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py off 3"
-        cmd_off: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py on 3"
+        cmd_on: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py on 3"
+        cmd_off: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py off 3"
 
       SerialDriver:
         txdelay: 0.05

--- a/targets/gl-mt300n-v2.yaml
+++ b/targets/gl-mt300n-v2.yaml
@@ -8,10 +8,10 @@ targets:
         port: "/dev/glinet-mango"
         speed: 115200
       
-#      SerialIsolatorResource:
-#        device: "/dev/arduino-relay"
-#        channel: 1
-#        baudrate: 115200
+      SerialIsolatorResource:
+        device: "/dev/arduino-relay"
+        channel: 1
+        baudrate: 115200
 
       NetworkService:
         address: "192.168.20.188"
@@ -19,10 +19,10 @@ targets:
 
     drivers:
       ExternalPowerDriver:
-        cmd_on: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py --port /dev/arduino-relay --baudrate 115200 off 0"
-        cmd_off: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py --port /dev/arduino-relay --baudrate 115200 on 0 1"
+        cmd_on: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py --port /dev/arduino-relay --baudrate 115200 on 0"
+        cmd_off: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py --port /dev/arduino-relay --baudrate 115200 off 0"
 
-      #SerialIsolatorDriver: {}
+      SerialIsolatorDriver: {}
 
       SerialDriver:
         txdelay: 0.05
@@ -49,3 +49,4 @@ targets:
 
 imports:
   - ../strategies/physicalstrategy.py
+  - ../drivers/serial_isolator_driver.py

--- a/targets/gl-mt300n-v2.yaml
+++ b/targets/gl-mt300n-v2.yaml
@@ -14,8 +14,9 @@ targets:
         baudrate: 115200
 
       NetworkService:
-        address: "192.168.20.188"
+        address: "192.168.20.181"
         username: "root"
+        password: "bestpi4ever"
 
     drivers:
       ExternalPowerDriver:

--- a/targets/gl-mt300n-v2.yaml
+++ b/targets/gl-mt300n-v2.yaml
@@ -1,0 +1,51 @@
+targets:
+  main:
+    features:
+      - power
+
+    resources:
+      RawSerialPort:
+        port: "/dev/glinet-mango"
+        speed: 115200
+      
+#      SerialIsolatorResource:
+#        device: "/dev/arduino-relay"
+#        channel: 1
+#        baudrate: 115200
+
+      NetworkService:
+        address: "192.168.20.188"
+        username: "root"
+
+    drivers:
+      ExternalPowerDriver:
+        cmd_on: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py --port /dev/arduino-relay --baudrate 115200 off 0"
+        cmd_off: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py --port /dev/arduino-relay --baudrate 115200 on 0 1"
+
+      #SerialIsolatorDriver: {}
+
+      SerialDriver:
+        txdelay: 0.05
+
+      ShellDriver:
+        prompt: 'root@[\w\-.]+:[/\w\-.~]+# '
+        login_prompt: '(?:GL-MT300N-V2|OpenWrt).* login: '
+        await_login_timeout: 15
+        login_timeout: 120
+        post_login_settle_time: 5
+        username: root
+        password: bestpi4ever
+
+      SSHDriver:
+        connection_timeout: 30.0
+        explicit_scp_mode: True
+
+      PhysicalDeviceStrategy:
+        requires_serial_disconnect: true
+        boot_wait: 60
+        connection_timeout: 60
+        smart_state_detection: true
+        fast_check_timeout: 3
+
+imports:
+  - ../strategies/physicalstrategy.py

--- a/targets/mesh_belkin_pair.yaml
+++ b/targets/mesh_belkin_pair.yaml
@@ -1,5 +1,5 @@
 targets:
-  main:
+  belkin_rt3200_1:
     features:
       - power
 
@@ -16,6 +16,46 @@ targets:
       ExternalPowerDriver:
         cmd_on: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py on 2"
         cmd_off: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py off 2"
+
+      SerialDriver:
+        txdelay: 0.05
+
+      ShellDriver:
+        prompt: '[\r\n]+.*?root@.*?#\s*'
+        login_prompt: 'Please press Enter to activate this console\.'
+        username: 'root'
+        await_login_timeout: 15
+        login_timeout: 120
+        post_login_settle_time: 5
+
+      SSHDriver:
+        connection_timeout: 30.0
+        explicit_scp_mode: True
+
+      PhysicalDeviceStrategy:
+        requires_serial_disconnect: false
+        boot_wait: 30
+        connection_timeout: 30
+        smart_state_detection: true
+        fast_check_timeout: 3
+
+  belkin_rt3200_2:
+    features:
+      - power
+
+    resources:
+      RawSerialPort:
+        port: "/dev/belkin-rt3200-2"
+        speed: 115200
+
+      NetworkService:
+        address: "192.168.20.183"
+        username: "root"
+
+    drivers:
+      ExternalPowerDriver:
+        cmd_on: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py on 3"
+        cmd_off: "python3 /home/franco/pi/pi-hil-testing-utils/scripts/arduino_relay_control.py off 3"
 
       SerialDriver:
         txdelay: 0.05

--- a/targets/qemu-libremesh-x86-64.yaml
+++ b/targets/qemu-libremesh-x86-64.yaml
@@ -1,0 +1,34 @@
+targets:
+  main:
+    features: [hwsim]
+    resources:
+      - NetworkService:
+          # The actual address will be filled in by the strategy
+          address: ""
+          port: 22
+          username: root
+
+    drivers:
+      - QEMUDriver:
+          qemu_bin: qemu_bin
+          machine: pc
+          cpu: max
+          memory: 128M
+          extra_args: "-device virtio-rng-pci -netdev user,id=wan -device virtio-net-pci,netdev=wan"
+          nic: "user,model=virtio-net-pci,net=10.13.0.0/16,id=lan"
+          disk: firmware
+      - ShellDriver:
+          login_prompt: Please press Enter to activate this console.
+          prompt: 'root@'
+          await_login_timeout: 30 
+          username: root
+      - SSHDriver:
+          username: root
+          explicit_scp_mode: True
+      - QEMUNetworkStrategy: {}
+
+tools:
+  qemu_bin: qemu-system-x86_64
+
+imports:
+  - ../strategies/qemunetworkstrategy.py

--- a/targets/qemu-libremesh-x86-64.yaml
+++ b/targets/qemu-libremesh-x86-64.yaml
@@ -1,6 +1,6 @@
 targets:
   main:
-    features: [hwsim]
+    features: [hwsim, libremesh]
     resources:
       - NetworkService:
           # The actual address will be filled in by the strategy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,3 +159,26 @@ def upload_vwifi(shell_command,target):
     assert "02:00:00:00:00:02" in stations                                                    
     assert "02:00:00:00:00:03" in stations 
     return ssh
+
+@pytest.fixture
+def shell_command_fast(strategy):
+    try:
+        strategy.transition("shell")
+        return strategy.shell
+    except Exception:
+        logger.exception("Failed to transition to state shell")
+        pytest.exit("Failed to transition to state shell", returncode=3)
+
+
+@pytest.fixture
+def shell_command_force_cycle(strategy):
+    try:
+        if hasattr(strategy, 'force_power_cycle'):
+            strategy.force_power_cycle()
+        else:
+            strategy.transition("shell")
+        return strategy.shell
+    except Exception:
+        logger.exception("Failed to transition to state shell")
+        pytest.exit("Failed to transition to state shell", returncode=3)
+

--- a/tests/test_libremesh_shared_state_async.py
+++ b/tests/test_libremesh_shared_state_async.py
@@ -1,0 +1,59 @@
+import json, re, time
+import logging
+import pytest
+
+N1 = "LiMe-000001"
+N2 = "LiMe-000002"
+N3 = "LiMe-000003"
+N1234 = "LiMe-123456"
+MAC1 = "02:58:47:00:00:01"
+MAC2 = "02:58:47:00:00:02"
+MAC3 = "02:58:47:00:00:03"
+MAC1234 = "02:58:47:12:34:56"
+
+
+logger = logging.getLogger(__name__)
+
+
+def _join_stdout(stdout):
+    if isinstance(stdout, (list, tuple)):
+        return "\n".join(stdout)
+    return stdout or ""
+
+def _extract_json_from_mixed(text):
+    i = text.find("{")
+    j = text.rfind("}")
+    assert i != -1 and j != -1 and j > i, f"Could not find JSON in output:\n{text}"
+    return json.loads(text[i:j+1])
+
+def _strip_mac(mac):
+    return mac.replace(":", "").lower()
+
+def _canonical_link_key(mac_a, mac_b):
+    a = _strip_mac(mac_a); b = _strip_mac(mac_b)
+    return "".join(sorted([a, b]))
+
+
+@pytest.mark.lg_feature("libremesh")
+def test_bat_links_info(upload_vwifi):
+    ssh_command = upload_vwifi
+    link_key_N1234_N1 = _canonical_link_key(MAC1234, MAC1)
+    link_key_N1234_N2 = _canonical_link_key(MAC1234, MAC2)
+    link_key_N1234_N3 = _canonical_link_key(MAC1234, MAC3)
+    
+    ssh_command.run_check("shared-state-async-publish-all")
+    ssh_command.run_check("shared-state-async sync bat_links_info")
+    time.sleep(15)
+    out, err, rc = ssh_command.run("shared-state-async get bat_links_info")
+    assert rc == 0, f"shared-state-async failed (rc={rc}) stderr={_join_stdout(err)}"
+    data = _extract_json_from_mixed(_join_stdout(out))
+
+    assert isinstance(data, dict) and data, "bat_links_info must be a non-empty dict"
+    logger.warning(out)
+    assert N1234 in data, f"Expected {N1234} in shared-state keys: {list(data.keys())}"
+    assert N1 in data, f"Expected {N1} in shared-state keys: {list(data.keys())}"
+    assert N2 in data, f"Expected {N2} in shared-state keys: {list(data.keys())}"
+    assert N3 in data, f"Expected {N3} in shared-state keys: {list(data.keys())}"
+    assert link_key_N1234_N1 in data[N1234]["links"],  f"Expected {link_key_N1234_N1} in shared-state keys: {list(data[N1234]['links'])}"
+    assert link_key_N1234_N2 in data[N1234]["links"],  f"Expected {link_key_N1234_N2} in shared-state keys: {list(data[N1234]['links'])}"
+    assert link_key_N1234_N3 in data[N1234]["links"],  f"Expected {link_key_N1234_N3} in shared-state keys: {list(data[N1234]['links'])}"


### PR DESCRIPTION
feat: Añade soporte para pruebas en dispositivos físicos y mejoras en Labgrid

Este PR introduce una funcionalidad para ejecutar pruebas automatizadas en dispositivos físicos OpenWrt/Libremesh utilizando Labgrid, además de optimizaciones en la estrategia de red para entornos QEMU y una mejor categorización de pruebas con nuevos marcadores de Pytest.

**Cambios Principales:**

-   **Estrategia `PhysicalDeviceStrategy`**: Implementa el control de encendido/apagado, conexión serial y de shell para routers físicos. Incluye un manejo especial para el aislamiento de línea serial requerido por ciertos dispositivos (ej. GL-iNet).
-   **`SerialIsolatorDriver`**: Añade un driver para gestionar relés Arduino y aislar/reconectar la línea serial, integrándose con la nueva estrategia física.
-   **Configuraciones de Targets Físicos**: Se han añadido archivos de configuración YAML para dispositivos como GL-MT300N-V2 y Belkin RT3200 (individuales y en par para pruebas de mesh).
-   **`QEMUNetworkStrategy` Mejorada**: Ahora la estrategia de red para QEMU detecta la dirección IP de la interfaz LAN dinámicamente, haciendo las pruebas más flexibles y menos dependientes de IPs hardcodeadas.
-   **Nuevos Marcadores de Pytest**: Se han definido un conjunto completo de marcadores de `pytest` en `pyproject.toml` para categorizar pruebas por feature, sistema, hardware, requisitos de ciclo de energía, y configuración de routers (e.g., `lg_hardware`, `lg_force_cycle`, `lg_mesh`).
-   **Actualización del `Makefile`**: Nuevos objetivos para ejecutar pruebas en los targets físicos recién definidos.

**Propósito:**

Estos cambios permiten expandir nuestras capacidades de testing para incluir hardware real, lo cual es fundamental para validar el comportamiento del firmware en condiciones físicas y para pruebas de red que involucren múltiples dispositivos. La mejora en la estrategia QEMU aumenta la robustez de las pruebas virtuales.
